### PR TITLE
Development

### DIFF
--- a/GitLabMobile/GitLabMobile.xcodeproj/project.pbxproj
+++ b/GitLabMobile/GitLabMobile.xcodeproj/project.pbxproj
@@ -10,9 +10,22 @@
 		CE8494CD2E4B783300B03BD6 /* GitLabMobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GitLabMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		CE849ACE2E4B99C400B03BD6 /* Exceptions for "GitLabMobile" folder in "GitLabMobile" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = CE8494CC2E4B783300B03BD6 /* GitLabMobile */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		CE8494CF2E4B783300B03BD6 /* GitLabMobile */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				CE849ACE2E4B99C400B03BD6 /* Exceptions for "GitLabMobile" folder in "GitLabMobile" target */,
+			);
 			path = GitLabMobile;
 			sourceTree = "<group>";
 		};
@@ -275,6 +288,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = GitLabMobile/Info.plist;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -313,6 +327,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = GitLabMobile/Info.plist;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/GitLabMobile/GitLabMobile/Features/Account/Data/PersonalProjectsService.swift
+++ b/GitLabMobile/GitLabMobile/Features/Account/Data/PersonalProjectsService.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public protocol PersonalProjectsServiceProtocol: Sendable {
+    func owned(page: Int, perPage: Int) async throws -> [ProjectSummary]
+    func starred(page: Int, perPage: Int) async throws -> [ProjectSummary]
+    func membership(page: Int, perPage: Int) async throws -> [ProjectSummary]
+}
+
+public struct PersonalProjectsService: PersonalProjectsServiceProtocol, Sendable {
+    private let api: APIClient
+
+    public init(api: APIClient) { self.api = api }
+
+    public func owned(page: Int = 1, perPage: Int = 20) async throws -> [ProjectSummary] {
+        try await api.send(ProjectsAPI.owned(page: page, perPage: perPage))
+    }
+
+    public func starred(page: Int = 1, perPage: Int = 20) async throws -> [ProjectSummary] {
+        try await api.send(ProjectsAPI.starred(page: page, perPage: perPage))
+    }
+
+    public func membership(page: Int = 1, perPage: Int = 20) async throws -> [ProjectSummary] {
+        try await api.send(ProjectsAPI.membership(page: page, perPage: perPage))
+    }
+}
+

--- a/GitLabMobile/GitLabMobile/Features/Account/Data/PersonalProjectsService.swift
+++ b/GitLabMobile/GitLabMobile/Features/Account/Data/PersonalProjectsService.swift
@@ -23,4 +23,3 @@ public struct PersonalProjectsService: PersonalProjectsServiceProtocol, Sendable
         try await api.send(ProjectsAPI.membership(page: page, perPage: perPage))
     }
 }
-

--- a/GitLabMobile/GitLabMobile/Features/Explore/Data/ExploreProjectsService.swift
+++ b/GitLabMobile/GitLabMobile/Features/Explore/Data/ExploreProjectsService.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public protocol ExploreProjectsServiceProtocol: Sendable {
+    func getTrending(page: Int, perPage: Int) async throws -> [ProjectSummary]
+    func getMostStarred(page: Int, perPage: Int) async throws -> [ProjectSummary]
+    func search(_ query: String, page: Int, perPage: Int) async throws -> [ProjectSummary]
+}
+
+public struct ExploreProjectsService: ExploreProjectsServiceProtocol, Sendable {
+    private let api: APIClient
+
+    public init(api: APIClient) { self.api = api }
+
+    public func getTrending(page: Int = 1, perPage: Int = 20) async throws -> [ProjectSummary] {
+        try await api.send(ProjectsAPI.trending(page: page, perPage: perPage))
+    }
+
+    public func getMostStarred(page: Int = 1, perPage: Int = 20) async throws -> [ProjectSummary] {
+        try await api.send(ProjectsAPI.mostStarred(page: page, perPage: perPage))
+    }
+
+    public func search(_ query: String, page: Int = 1, perPage: Int = 20) async throws -> [ProjectSummary] {
+        try await api.send(ProjectsAPI.search(query, page: page, perPage: perPage))
+    }
+}
+

--- a/GitLabMobile/GitLabMobile/Features/Explore/Data/ExploreProjectsService.swift
+++ b/GitLabMobile/GitLabMobile/Features/Explore/Data/ExploreProjectsService.swift
@@ -23,4 +23,3 @@ public struct ExploreProjectsService: ExploreProjectsServiceProtocol, Sendable {
         try await api.send(ProjectsAPI.search(query, page: page, perPage: perPage))
     }
 }
-

--- a/GitLabMobile/GitLabMobile/Features/Explore/Presentation/UIModels/ProjectRowItem.swift
+++ b/GitLabMobile/GitLabMobile/Features/Explore/Presentation/UIModels/ProjectRowItem.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct ProjectRowItem: Identifiable, Sendable, Equatable {
+    public let id: Int
+    public let title: String
+    public let subtitle: String
+    public let starsText: String
+    public let avatarURL: URL?
+
+    public init(from domain: ProjectSummary) {
+        self.id = domain.id
+        self.title = domain.name
+        self.subtitle = domain.pathWithNamespace
+        self.starsText = "\(domain.starCount)"
+        self.avatarURL = domain.avatarUrl
+    }
+}

--- a/GitLabMobile/GitLabMobile/Features/Projects/Data/ProjectDetailsService.swift
+++ b/GitLabMobile/GitLabMobile/Features/Projects/Data/ProjectDetailsService.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public protocol ProjectDetailsServiceProtocol: Sendable {
+    func getProject(id: Int) async throws -> ProjectSummary
+}
+
+public struct ProjectDetailsService: ProjectDetailsServiceProtocol, Sendable {
+    private let api: APIClient
+
+    public init(api: APIClient) { self.api = api }
+
+    public func getProject(id: Int) async throws -> ProjectSummary {
+        try await api.send(ProjectsAPI.project(id: id))
+    }
+}
+

--- a/GitLabMobile/GitLabMobile/Features/Projects/Data/ProjectDetailsService.swift
+++ b/GitLabMobile/GitLabMobile/Features/Projects/Data/ProjectDetailsService.swift
@@ -13,4 +13,3 @@ public struct ProjectDetailsService: ProjectDetailsServiceProtocol, Sendable {
         try await api.send(ProjectsAPI.project(id: id))
     }
 }
-

--- a/GitLabMobile/GitLabMobile/Features/Search/Data/ProjectSearchService.swift
+++ b/GitLabMobile/GitLabMobile/Features/Search/Data/ProjectSearchService.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public protocol ProjectSearchServiceProtocol: Sendable {
+    func search(_ query: String, page: Int, perPage: Int) async throws -> [ProjectSummary]
+}
+
+public struct ProjectSearchService: ProjectSearchServiceProtocol, Sendable {
+    private let api: APIClient
+    public init(api: APIClient) { self.api = api }
+
+    public func search(_ query: String, page: Int = 1, perPage: Int = 20) async throws -> [ProjectSummary] {
+        try await api.send(ProjectsAPI.search(query, page: page, perPage: perPage))
+    }
+}
+

--- a/GitLabMobile/GitLabMobile/Features/Search/Data/ProjectSearchService.swift
+++ b/GitLabMobile/GitLabMobile/Features/Search/Data/ProjectSearchService.swift
@@ -12,4 +12,3 @@ public struct ProjectSearchService: ProjectSearchServiceProtocol, Sendable {
         try await api.send(ProjectsAPI.search(query, page: page, perPage: perPage))
     }
 }
-

--- a/GitLabMobile/GitLabMobile/GitLabMobileApp.swift
+++ b/GitLabMobile/GitLabMobile/GitLabMobileApp.swift
@@ -12,6 +12,23 @@ struct GitLabMobileApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(\.appEnvironment, Self.makeEnvironment())
         }
+    }
+
+    private static func makeEnvironment() -> AppEnvironment {
+        let config = AppNetworkingConfig.loadFromInfoPlist()
+        let oauth = OAuthService(baseURL: config.baseURL)
+        let authManager = AuthorizationManager(oauthService: oauth)
+        let pins = AppPinning.loadPinsFromInfoPlist()
+        let sessionDelegate = PinnedSessionDelegate(pins: pins)
+        let client = APIClient(config: config, sessionDelegate: sessionDelegate, authProvider: authManager)
+        return AppEnvironment(
+            apiClient: client,
+            exploreService: ExploreProjectsService(api: client),
+            personalProjectsService: PersonalProjectsService(api: client),
+            projectDetailsService: ProjectDetailsService(api: client),
+            authManager: authManager
+        )
     }
 }

--- a/GitLabMobile/GitLabMobile/Info.plist
+++ b/GitLabMobile/GitLabMobile/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>GitLabConfiguration</key>
+	<dict>
+		<key>GitLabAPIPrefix</key>
+		<string>/api/v4</string>
+		<key>GitLabBaseURL</key>
+		<string>https://gitlab.com</string>
+	</dict>
+</dict>
+</plist>

--- a/GitLabMobile/GitLabMobile/Shared/AppEnvironment.swift
+++ b/GitLabMobile/GitLabMobile/Shared/AppEnvironment.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+public struct AppEnvironment {
+    public let apiClient: APIClient
+    public let exploreService: ExploreProjectsService
+    public let personalProjectsService: PersonalProjectsService
+    public let projectDetailsService: ProjectDetailsService
+    public let authManager: AuthorizationManager
+}
+
+private struct AppEnvironmentKey: EnvironmentKey {
+    static let defaultValue: AppEnvironment = {
+        let config = AppNetworkingConfig.loadFromInfoPlist()
+        let oauthService = OAuthService(baseURL: config.baseURL)
+        let authManager = AuthorizationManager(storage: KeychainTokenStorage(), oauthService: oauthService)
+        // API client with pinning delegate and auth provider
+        let sessionDelegate = PinnedSessionDelegate()
+        let client = APIClient(config: config, sessionDelegate: sessionDelegate, authProvider: authManager)
+        return AppEnvironment(
+            apiClient: client,
+            exploreService: ExploreProjectsService(api: client),
+            personalProjectsService: PersonalProjectsService(api: client),
+            projectDetailsService: ProjectDetailsService(api: client),
+            authManager: authManager
+        )
+    }()
+}
+
+public extension EnvironmentValues {
+    var appEnvironment: AppEnvironment {
+        get { self[AppEnvironmentKey.self] }
+        set { self[AppEnvironmentKey.self] = newValue }
+    }
+}

--- a/GitLabMobile/GitLabMobile/Shared/Domain/Entities/AuthToken.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Domain/Entities/AuthToken.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public struct AuthToken: Codable, Sendable, Equatable {
+    public let accessToken: String
+    public let tokenType: String
+    public let refreshToken: String?
+    public let expiresIn: Int?
+    public let createdAt: TimeInterval? // seconds since epoch
+    public let scope: String?
+
+    public init(
+        accessToken: String,
+        tokenType: String,
+        refreshToken: String?,
+        expiresIn: Int?,
+        createdAt: TimeInterval?,
+        scope: String?
+    ) {
+        self.accessToken = accessToken
+        self.tokenType = tokenType
+        self.refreshToken = refreshToken
+        self.expiresIn = expiresIn
+        self.createdAt = createdAt
+        self.scope = scope
+    }
+
+    public var isExpired: Bool {
+        guard let expiresIn, let createdAt else { return false }
+        let expiry = Date(timeIntervalSince1970: createdAt).addingTimeInterval(TimeInterval(expiresIn))
+        return expiry.addingTimeInterval(-10) <= Date()
+    }
+}

--- a/GitLabMobile/GitLabMobile/Shared/Domain/Entities/ProjectSummary.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Domain/Entities/ProjectSummary.swift
@@ -11,4 +11,3 @@ public struct ProjectSummary: Identifiable, Decodable, Equatable, Sendable {
     public let webUrl: URL
     public let lastActivityAt: Date?
 }
-

--- a/GitLabMobile/GitLabMobile/Shared/Domain/Entities/ProjectSummary.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Domain/Entities/ProjectSummary.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public struct ProjectSummary: Identifiable, Decodable, Equatable, Sendable {
+    public let id: Int
+    public let name: String
+    public let pathWithNamespace: String
+    public let description: String?
+    public let starCount: Int
+    public let forksCount: Int
+    public let avatarUrl: URL?
+    public let webUrl: URL
+    public let lastActivityAt: Date?
+}
+

--- a/GitLabMobile/GitLabMobile/Shared/Networking/APIClient+Config.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/APIClient+Config.swift
@@ -1,8 +1,16 @@
 import Foundation
 
 public extension APIClient {
-    init(config: NetworkingConfig, sessionDelegate: URLSessionDelegate? = nil, authProvider: AuthProviding? = nil) {
-        self.init(baseURL: config.baseURL, apiPrefix: config.apiPrefix, sessionDelegate: sessionDelegate, authProvider: authProvider)
+    init(
+        config: NetworkingConfig,
+        sessionDelegate: URLSessionDelegate? = nil,
+        authProvider: AuthProviding? = nil
+    ) {
+        self.init(
+            baseURL: config.baseURL,
+            apiPrefix: config.apiPrefix,
+            sessionDelegate: sessionDelegate,
+            authProvider: authProvider
+        )
     }
 }
-

--- a/GitLabMobile/GitLabMobile/Shared/Networking/APIClient+Config.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/APIClient+Config.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public extension APIClient {
+    init(config: NetworkingConfig, sessionDelegate: URLSessionDelegate? = nil, authProvider: AuthProviding? = nil) {
+        self.init(baseURL: config.baseURL, apiPrefix: config.apiPrefix, sessionDelegate: sessionDelegate, authProvider: authProvider)
+    }
+}
+

--- a/GitLabMobile/GitLabMobile/Shared/Networking/APIClient.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/APIClient.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+public struct APIClient {
+    public let baseURL: URL
+    public let apiPrefix: String
+    public let urlSession: URLSession
+    private let authProvider: AuthProviding?
+
+    public init(
+        baseURL: URL,
+        apiPrefix: String = "/api/v4",
+        sessionDelegate: URLSessionDelegate? = nil,
+        authProvider: AuthProviding? = nil
+    ) {
+        self.baseURL = baseURL
+        self.apiPrefix = apiPrefix
+        let config = URLSessionConfiguration.default
+        config.waitsForConnectivity = true
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        self.urlSession = URLSession(configuration: config, delegate: sessionDelegate, delegateQueue: nil)
+        self.authProvider = authProvider
+    }
+
+    public func send<Response: Decodable>(_ endpoint: Endpoint<Response>) async throws -> Response {
+        let url = try buildURL(for: endpoint)
+        var request = makeRequest(url: url, endpoint: endpoint)
+        await applyAuthIfAvailable(&request)
+        let (data, http) = try await perform(request)
+        return try decode(Response.self, data: data, http: http)
+    }
+}
+
+// MARK: - Private helpers
+private extension APIClient {
+    func buildURL<Response>(for endpoint: Endpoint<Response>) throws -> URL {
+        let fullPath = endpoint.isAbsolutePath ? endpoint.path : (apiPrefix + endpoint.path)
+        guard var components = URLComponents(url: baseURL.appendingPathComponent(fullPath),
+                                             resolvingAgainstBaseURL: false) else {
+            throw NetworkError.invalidURL
+        }
+        components.queryItems = endpoint.queryItems.isEmpty ? nil : endpoint.queryItems
+        guard let url = components.url else { throw NetworkError.invalidURL }
+        return url
+    }
+
+    func makeRequest<Response>(url: URL, endpoint: Endpoint<Response>) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = endpoint.method.rawValue
+        request.httpBody = endpoint.body
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        endpoint.headers.forEach { request.setValue($1, forHTTPHeaderField: $0) }
+        return request
+    }
+
+    func applyAuthIfAvailable(_ request: inout URLRequest) async {
+        if let header = await authProvider?.authorizationHeader() {
+            request.setValue(header, forHTTPHeaderField: "Authorization")
+        }
+    }
+
+    func perform(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        do {
+            let (data, response) = try await urlSession.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw NetworkError.transport(URLError(.badServerResponse))
+            }
+            return (data, http)
+        } catch {
+            if let error = error as? NetworkError { throw error }
+            throw NetworkError.transport(error)
+        }
+    }
+
+    func decode<R: Decodable>(_ type: R.Type, data: Data, http: HTTPURLResponse) throws -> R {
+        switch http.statusCode {
+        case 200..<300:
+            if R.self == Data.self, let raw = data as? R { return raw }
+            do { return try JSONDecoder.gitLab.decode(R.self, from: data) } catch { throw NetworkError.decoding(error) }
+        case 401:
+            throw NetworkError.unauthorized
+        default:
+            throw NetworkError.server(statusCode: http.statusCode, data: data)
+        }
+    }
+}
+

--- a/GitLabMobile/GitLabMobile/Shared/Networking/APIClient.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/APIClient.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct APIClient {
+public struct APIClient: Sendable {
     public let baseURL: URL
     public let apiPrefix: String
     public let urlSession: URLSession
@@ -83,4 +83,3 @@ private extension APIClient {
         }
     }
 }
-

--- a/GitLabMobile/GitLabMobile/Shared/Networking/AppPinning.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/AppPinning.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Loads SPKI pin hashes from Info.plist top-level key `GitLabSPKIPins` (Array<String>).
+/// Each entry can be either the raw Base64 hash or prefixed with `sha256//`.
+public enum AppPinning {
+    public static func loadPinsFromInfoPlist() -> Set<String> {
+        guard let pins = Bundle.main.object(forInfoDictionaryKey: "GitLabSPKIPins") as? [String] else {
+            return []
+        }
+        return Set(pins)
+    }
+}
+
+// trailing newline intentional

--- a/GitLabMobile/GitLabMobile/Shared/Networking/Auth/AuthorizationManager.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/Auth/AuthorizationManager.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public protocol AuthorizationManagerProtocol: Sendable {
+    func getValidToken() async throws -> AuthToken
+    func store(_ token: AuthToken) async throws
+    func signOut() async throws
+}
+
+public actor AuthorizationManager: AuthorizationManagerProtocol, AuthProviding {
+    private let storage: TokenStorage
+    private let oauthService: OAuthService
+    private var cached: AuthToken?
+    private var refreshTask: Task<AuthToken, Error>?
+
+    public init(storage: TokenStorage = KeychainTokenStorage(), oauthService: OAuthService) {
+        self.storage = storage
+        self.oauthService = oauthService
+    }
+
+    public func store(_ token: AuthToken) async throws {
+        try storage.save(token)
+        cached = token
+    }
+
+    public func signOut() async throws {
+        try storage.clear()
+        cached = nil
+        refreshTask?.cancel(); refreshTask = nil
+    }
+
+    public func getValidToken() async throws -> AuthToken {
+        if let token = cached ?? (try? storage.load()) {
+            cached = token
+            if token.isExpired, let refresh = token.refreshToken {
+                return try await refreshIfNeeded(refreshToken: refresh)
+            }
+            return token
+        }
+        throw NetworkError.unauthorized
+    }
+
+    private func refreshIfNeeded(refreshToken: String) async throws -> AuthToken {
+        if let task = refreshTask { return try await task.value }
+        let task = Task { () throws -> AuthToken in
+            defer { refreshTask = nil }
+            let refreshed = try await oauthService.refreshToken(refreshToken)
+            try storage.save(refreshed)
+            cached = refreshed
+            return refreshed
+        }
+        refreshTask = task
+        return try await task.value
+    }
+
+    // AuthProviding
+    public func authorizationHeader() async -> String? {
+        do {
+            let token = try await getValidToken()
+            return "Bearer \(token.accessToken)"
+        } catch { return nil }
+    }
+}

--- a/GitLabMobile/GitLabMobile/Shared/Networking/Auth/OAuthService.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/Auth/OAuthService.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+public struct OAuthService: Sendable {
+    private let baseURL: URL
+    private let session: URLSession
+
+    public init(baseURL: URL, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func exchangeCode(
+        code: String,
+        redirectURI: String,
+        clientId: String,
+        codeVerifier: String
+    ) async throws -> AuthToken {
+        let endpoint = OAuthEndpoints.exchange(
+            code: code,
+            redirectURI: redirectURI,
+            clientId: clientId,
+            codeVerifier: codeVerifier
+        )
+        let request = try endpoint.request(baseURL: baseURL)
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+            throw NetworkError.server(statusCode: (response as? HTTPURLResponse)?.statusCode ?? -1, data: data)
+        }
+        let decoded = try JSONDecoder().decode(OAuthTokenResponse.self, from: data)
+        return decoded.toDomain()
+    }
+
+    public func refreshToken(_ refreshToken: String, clientId: String? = nil) async throws -> AuthToken {
+        let endpoint = OAuthEndpoints.refresh(refreshToken: refreshToken, clientId: clientId)
+        let request = try endpoint.request(baseURL: baseURL)
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+            throw NetworkError.server(statusCode: (response as? HTTPURLResponse)?.statusCode ?? -1, data: data)
+        }
+        let decoded = try JSONDecoder().decode(OAuthTokenResponse.self, from: data)
+        return decoded.toDomain()
+    }
+}

--- a/GitLabMobile/GitLabMobile/Shared/Networking/Auth/OAuthToken.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/Auth/OAuthToken.swift
@@ -1,0 +1,1 @@
+// Intentionally left empty; DTO moved to Networking/DTOs/Auth and domain token to Shared/Domain.

--- a/GitLabMobile/GitLabMobile/Shared/Networking/Auth/TokenStorage.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/Auth/TokenStorage.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Security
+
+public protocol TokenStorage: Sendable {
+    func save(_ token: AuthToken) throws
+    func load() throws -> AuthToken?
+    func clear() throws
+}
+
+public final class KeychainTokenStorage: TokenStorage {
+    private let service: String
+    private let account: String
+
+    public init(
+        service: String = Bundle.main.bundleIdentifier ?? "GitLabMobile",
+        account: String = "oauth_token"
+    ) {
+        self.service = service
+        self.account = account
+    }
+
+    public func save(_ token: AuthToken) throws {
+        let data = try JSONEncoder().encode(token)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data
+        ]
+        SecItemDelete(query as CFDictionary)
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            let error = NSError(domain: NSOSStatusErrorDomain, code: Int(status))
+            throw NetworkError.transport(error)
+        }
+    }
+
+    public func load() throws -> AuthToken? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess, let data = result as? Data else {
+            throw NetworkError.transport(NSError(domain: NSOSStatusErrorDomain, code: Int(status)))
+        }
+        return try JSONDecoder().decode(AuthToken.self, from: data)
+    }
+
+    public func clear() throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/GitLabMobile/GitLabMobile/Shared/Networking/AuthProviding.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/AuthProviding.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public protocol AuthProviding: Sendable {
+    /// Return full Authorization header value, e.g. "Bearer <token>"
+    func authorizationHeader() async -> String?
+}
+

--- a/GitLabMobile/GitLabMobile/Shared/Networking/AuthProviding.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/AuthProviding.swift
@@ -4,4 +4,3 @@ public protocol AuthProviding: Sendable {
     /// Return full Authorization header value, e.g. "Bearer <token>"
     func authorizationHeader() async -> String?
 }
-

--- a/GitLabMobile/GitLabMobile/Shared/Networking/DTOs/Auth/OAuthTokenResponse+Mapping.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/DTOs/Auth/OAuthTokenResponse+Mapping.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public extension OAuthTokenResponse {
+    func toDomain() -> AuthToken {
+        AuthToken(
+            accessToken: accessToken,
+            tokenType: tokenType,
+            refreshToken: refreshToken,
+            expiresIn: expiresIn,
+            createdAt: createdAt,
+            scope: scope
+        )
+    }
+}

--- a/GitLabMobile/GitLabMobile/Shared/Networking/DTOs/Auth/OAuthTokenResponse.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/DTOs/Auth/OAuthTokenResponse.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct OAuthTokenResponse: Codable, Sendable {
+    public let accessToken: String
+    public let tokenType: String
+    public let refreshToken: String?
+    public let expiresIn: Int?
+    public let createdAt: TimeInterval?
+    public let scope: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case tokenType = "token_type"
+        case refreshToken = "refresh_token"
+        case expiresIn = "expires_in"
+        case createdAt = "created_at"
+        case scope
+    }
+}

--- a/GitLabMobile/GitLabMobile/Shared/Networking/DTOs/Projects/ProjectDTO.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/DTOs/Projects/ProjectDTO.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct ProjectDTO: Decodable, Sendable {
+    public let id: Int
+    public let name: String
+    public let pathWithNamespace: String
+    public let description: String?
+    public let starCount: Int?
+    public let forksCount: Int?
+    public let avatarUrl: String?
+    public let webUrl: String
+    public let lastActivityAt: Date?
+}
+
+public extension ProjectDTO {
+    func toDomain() -> ProjectSummary {
+        ProjectSummary(
+            id: id,
+            name: name,
+            pathWithNamespace: pathWithNamespace,
+            description: description,
+            starCount: starCount ?? 0,
+            forksCount: forksCount ?? 0,
+            avatarUrl: avatarUrl.flatMap(URL.init),
+            webUrl: URL(string: webUrl) ?? URL(string: "https://gitlab.com") ?? URL(fileURLWithPath: "/"),
+            lastActivityAt: lastActivityAt
+        )
+    }
+}

--- a/GitLabMobile/GitLabMobile/Shared/Networking/Endpoint.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/Endpoint.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public struct Endpoint<Response: Decodable> {
+    // Relative path by default; can be absolute when `isAbsolutePath == true`
+    public var path: String
+    public var method: HTTPMethod
+    public var queryItems: [URLQueryItem]
+    public var headers: [String: String]
+    public var body: Data?
+
+    // If true, `path` is treated as absolute and no prefix will be applied
+    public var isAbsolutePath: Bool
+
+    public init(
+        path: String,
+        method: HTTPMethod = .get,
+        queryItems: [URLQueryItem] = [],
+        headers: [String: String] = [:],
+        body: Data? = nil,
+        isAbsolutePath: Bool = false
+    ) {
+        self.path = path
+        self.method = method
+        self.queryItems = queryItems
+        self.headers = headers
+        self.body = body
+        self.isAbsolutePath = isAbsolutePath
+    }
+}
+

--- a/GitLabMobile/GitLabMobile/Shared/Networking/Endpoint.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/Endpoint.swift
@@ -27,4 +27,3 @@ public struct Endpoint<Response: Decodable> {
         self.isAbsolutePath = isAbsolutePath
     }
 }
-

--- a/GitLabMobile/GitLabMobile/Shared/Networking/Endpoints/OAuthEndpoints.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/Endpoints/OAuthEndpoints.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+public enum OAuthEndpoints {
+    case exchange(code: String, redirectURI: String, clientId: String, codeVerifier: String)
+    case refresh(refreshToken: String, clientId: String? = nil)
+
+    // Raw URLRequest because OAuth uses different prefix and form encoding
+    func request(baseURL: URL) throws -> URLRequest {
+        switch self {
+        case let .exchange(code, redirectURI, clientId, codeVerifier):
+            var req = URLRequest(url: baseURL.appendingPathComponent("/oauth/token"))
+            req.httpMethod = "POST"
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            let body: [String: String] = [
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirectURI,
+                "client_id": clientId,
+                "code_verifier": codeVerifier
+            ]
+            req.httpBody = try JSONSerialization.data(withJSONObject: body)
+            return req
+        case let .refresh(refreshToken, clientId):
+            var req = URLRequest(url: baseURL.appendingPathComponent("/oauth/token"))
+            req.httpMethod = "POST"
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            var body: [String: String] = [
+                "grant_type": "refresh_token",
+                "refresh_token": refreshToken
+            ]
+            if let clientId { body["client_id"] = clientId }
+            req.httpBody = try JSONSerialization.data(withJSONObject: body)
+            return req
+        }
+    }
+
+    public func refresh(refreshToken: String) async throws -> OAuthTokenResponse {
+        fatalError("Use AuthorizationManager with configured OAuthEndpoints")
+    }
+}

--- a/GitLabMobile/GitLabMobile/Shared/Networking/Endpoints/ProjectsAPI.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/Endpoints/ProjectsAPI.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+public enum ProjectsAPI {
+    // Public explore
+    public static func trending(page: Int = 1, perPage: Int = 20) -> Endpoint<[ProjectSummary]> {
+        Endpoint(
+            path: "/projects",
+            queryItems: [
+                .init(name: "page", value: String(page)),
+                .init(name: "per_page", value: String(perPage)),
+                .init(name: "order_by", value: "last_activity_at"),
+                .init(name: "sort", value: "desc"),
+                .init(name: "visibility", value: "public")
+            ]
+        )
+    }
+
+    public static func mostStarred(page: Int = 1, perPage: Int = 20) -> Endpoint<[ProjectSummary]> {
+        Endpoint(
+            path: "/projects",
+            queryItems: [
+                .init(name: "page", value: String(page)),
+                .init(name: "per_page", value: String(perPage)),
+                .init(name: "order_by", value: "star_count"),
+                .init(name: "sort", value: "desc"),
+                .init(name: "visibility", value: "public")
+            ]
+        )
+    }
+
+    public static func search(_ query: String, page: Int = 1, perPage: Int = 20) -> Endpoint<[ProjectSummary]> {
+        Endpoint(
+            path: "/projects",
+            queryItems: [
+                .init(name: "page", value: String(page)),
+                .init(name: "per_page", value: String(perPage)),
+                .init(name: "search", value: query),
+                .init(name: "visibility", value: "public")
+            ]
+        )
+    }
+
+    // Authenticated
+    public static func owned(page: Int = 1, perPage: Int = 20) -> Endpoint<[ProjectSummary]> {
+        Endpoint(
+            path: "/projects",
+            queryItems: [
+                .init(name: "page", value: String(page)),
+                .init(name: "per_page", value: String(perPage)),
+                .init(name: "owned", value: "true")
+            ]
+        )
+    }
+
+    public static func starred(page: Int = 1, perPage: Int = 20) -> Endpoint<[ProjectSummary]> {
+        Endpoint(
+            path: "/projects",
+            queryItems: [
+                .init(name: "page", value: String(page)),
+                .init(name: "per_page", value: String(perPage)),
+                .init(name: "starred", value: "true")
+            ]
+        )
+    }
+
+    public static func membership(page: Int = 1, perPage: Int = 20) -> Endpoint<[ProjectSummary]> {
+        Endpoint(
+            path: "/projects",
+            queryItems: [
+                .init(name: "page", value: String(page)),
+                .init(name: "per_page", value: String(perPage)),
+                .init(name: "membership", value: "true")
+            ]
+        )
+    }
+
+    public static func project(id: Int) -> Endpoint<ProjectSummary> {
+        Endpoint(path: "/projects/\(id)")
+    }
+}
+

--- a/GitLabMobile/GitLabMobile/Shared/Networking/Endpoints/ProjectsAPI.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/Endpoints/ProjectsAPI.swift
@@ -78,4 +78,3 @@ public enum ProjectsAPI {
         Endpoint(path: "/projects/\(id)")
     }
 }
-

--- a/GitLabMobile/GitLabMobile/Shared/Networking/HTTPMethod.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/HTTPMethod.swift
@@ -5,4 +5,3 @@ public enum HTTPMethod: String {
     case patch = "PATCH"
     case delete = "DELETE"
 }
-

--- a/GitLabMobile/GitLabMobile/Shared/Networking/HTTPMethod.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/HTTPMethod.swift
@@ -1,0 +1,8 @@
+public enum HTTPMethod: String {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case patch = "PATCH"
+    case delete = "DELETE"
+}
+

--- a/GitLabMobile/GitLabMobile/Shared/Networking/JSONDecoder+GitLab.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/JSONDecoder+GitLab.swift
@@ -8,4 +8,3 @@ public extension JSONDecoder {
         return decoder
     }
 }
-

--- a/GitLabMobile/GitLabMobile/Shared/Networking/JSONDecoder+GitLab.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/JSONDecoder+GitLab.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public extension JSONDecoder {
+    static var gitLab: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}
+

--- a/GitLabMobile/GitLabMobile/Shared/Networking/NetworkError.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/NetworkError.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public enum NetworkError: Error, LocalizedError {
+    case invalidURL
+    case transport(Error)
+    case server(statusCode: Int, data: Data?)
+    case decoding(Error)
+    case unauthorized
+    case trustEvaluationFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid URL"
+        case .transport(let error):
+            return error.localizedDescription
+        case .server(let status, _):
+            return "Server error (\(status))"
+        case .decoding(let error):
+            return "Decoding error: \(error.localizedDescription)"
+        case .unauthorized:
+            return "Unauthorized"
+        case .trustEvaluationFailed:
+            return "Certificate pinning failed"
+        }
+    }
+}
+

--- a/GitLabMobile/GitLabMobile/Shared/Networking/NetworkError.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/NetworkError.swift
@@ -25,4 +25,3 @@ public enum NetworkError: Error, LocalizedError {
         }
     }
 }
-

--- a/GitLabMobile/GitLabMobile/Shared/Networking/NetworkingConfig.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/NetworkingConfig.swift
@@ -13,14 +13,15 @@ public struct NetworkingConfig: Sendable {
 public enum AppNetworkingConfig {
     public static func loadFromInfoPlist() -> NetworkingConfig {
         if let dict = Bundle.main.infoDictionary,
-           let gl = dict["GitLabConfiguration"] as? [String: Any],
-           let base = gl["BaseURL"] as? String,
+           let gitLab = dict["GitLabConfiguration"] as? [String: Any],
+           let base = gitLab["BaseURL"] as? String,
            let baseURL = URL(string: base) {
-            let prefix = (gl["APIPrefix"] as? String) ?? "/api/v4"
+            let prefix = (gitLab["APIPrefix"] as? String) ?? "/api/v4"
             return NetworkingConfig(baseURL: baseURL, apiPrefix: prefix)
         }
         // Fallback to gitlab.com
-        return NetworkingConfig(baseURL: URL(string: "https://gitlab.com")!, apiPrefix: "/api/v4")
+        // Avoid force unwrapping
+        let fallbackURL = URL(string: "https://gitlab.com") ?? URL(fileURLWithPath: "/")
+        return NetworkingConfig(baseURL: fallbackURL, apiPrefix: "/api/v4")
     }
 }
-

--- a/GitLabMobile/GitLabMobile/Shared/Networking/NetworkingConfig.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/NetworkingConfig.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public struct NetworkingConfig: Sendable {
+    public let baseURL: URL
+    public let apiPrefix: String
+
+    public init(baseURL: URL, apiPrefix: String = "/api/v4") {
+        self.baseURL = baseURL
+        self.apiPrefix = apiPrefix
+    }
+}
+
+public enum AppNetworkingConfig {
+    public static func loadFromInfoPlist() -> NetworkingConfig {
+        if let dict = Bundle.main.infoDictionary,
+           let gl = dict["GitLabConfiguration"] as? [String: Any],
+           let base = gl["BaseURL"] as? String,
+           let baseURL = URL(string: base) {
+            let prefix = (gl["APIPrefix"] as? String) ?? "/api/v4"
+            return NetworkingConfig(baseURL: baseURL, apiPrefix: prefix)
+        }
+        // Fallback to gitlab.com
+        return NetworkingConfig(baseURL: URL(string: "https://gitlab.com")!, apiPrefix: "/api/v4")
+    }
+}
+

--- a/GitLabMobile/GitLabMobile/Shared/Networking/PinnedSessionDelegate.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/PinnedSessionDelegate.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Security
+import CommonCrypto
+
+public final class PinnedSessionDelegate: NSObject, URLSessionDelegate {
+    // TODO: populate with Base64-encoded SHA-256 of the SPKI public key(s) for gitlab.com and any self-hosted domains
+    private let pinnedSPKISHA256Base64: Set<String>
+
+    public init(pins: Set<String> = []) {
+        self.pinnedSPKISHA256Base64 = pins
+        super.init()
+    }
+
+    public func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let trust = challenge.protectionSpace.serverTrust else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+
+        guard let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate],
+              let leaf = chain.first,
+              let publicKey = SecCertificateCopyKey(leaf) else {
+            completionHandler(.cancelAuthenticationChallenge, nil)
+            return
+        }
+
+        var error: Unmanaged<CFError>?
+        guard let keyData = SecKeyCopyExternalRepresentation(publicKey, &error) as Data? else {
+            completionHandler(.cancelAuthenticationChallenge, nil)
+            return
+        }
+
+        let hash = sha256(keyData).base64EncodedString()
+
+        if pinnedSPKISHA256Base64.isEmpty || pinnedSPKISHA256Base64.contains(hash) {
+            completionHandler(.useCredential, URLCredential(trust: trust))
+        } else {
+            completionHandler(.cancelAuthenticationChallenge, nil)
+        }
+    }
+
+    private func sha256(_ data: Data) -> Data {
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        data.withUnsafeBytes { buffer in
+            _ = CC_SHA256(buffer.baseAddress, CC_LONG(data.count), &hash)
+        }
+        return Data(hash)
+    }
+}
+


### PR DESCRIPTION
## Summary
This PR merges development into main and introduces a networking foundation with authentication, certificate pinning, and per‑resource endpoints, plus initial feature‑scoped services.

## Type of Change
- [x] New feature
- [x] Configuration/Setup
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Changes Made
- Networking core (async/await):
  - APIClient with split helpers (buildURL, makeRequest, applyAuth, perform, decode)
  - Endpoint, HTTPMethod, NetworkError, JSONDecoder.gitLab
- Configuration:
  - Info.plist keys GitLabBaseURL, GitLabAPIPrefix
  - NetworkingConfig + AppNetworkingConfig (loads from Info.plist)
- Security:
  - PinnedSessionDelegate (SPKI pinning)
  - AppPinning loader (GitLabSPKIPins in Info.plist)
- Auth:
  - AuthProviding protocol
  - OAuthService (exchange/refresh)
  - KeychainTokenStorage
  - AuthorizationManager (actor) providing Authorization header
  - Domain AuthToken; DTO OAuthTokenResponse with mapper
- Endpoints (per resource):
  - ProjectsAPI (trending, mostStarred, search, owned, starred, membership, project)
- Feature services (scoped):
  - ExploreProjectsService
  - PersonalProjectsService
  - ProjectDetailsService
- App wiring:
  - AppEnvironment builds client/auth/services once and injects via Environment
- DTO/UI model:
  - ProjectDTO (Networking/DTOs)
  - ProjectRowItem (Explore/Presentation)

## Testing
- [x] Code compiles without warnings
- [x] SwiftLint passes (0 violations)
- [x] Manual testing: basic public endpoints fetch successfully
- [ ] Unit/UI tests added or updated
- [x] No regressions in existing functionality

## iOS Testing (if applicable)
- [x] Dark/Light mode compatible (foundation only)
- [ ] Screen sizes and iPad (N/A for networking)
- [ ] Orientation (N/A)
- [ ] Accessibility (N/A)
- [x] Performance: async/await URLSession without stalls

## Screenshots/Videos (if applicable)
N/A (networking foundation only)

## Additional Context
- Provide SPKI pins via GitLabSPKIPins (Info.plist). Include current + backup pins for gitlab.com; disable in Debug if needed.