### PR TITLE
chore: add license header template and apply headers to Swift files

### DIFF
--- a/GitLabMobile/GitLabMobile.xcodeproj/project.pbxproj
+++ b/GitLabMobile/GitLabMobile.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 
 /* Begin PBXFileReference section */
 		CE8494CD2E4B783300B03BD6 /* GitLabMobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GitLabMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		CEDB7CAB2E4D564900A7583B /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -52,6 +53,7 @@
 			children = (
 				CE8494CF2E4B783300B03BD6 /* GitLabMobile */,
 				CE8494CE2E4B783300B03BD6 /* Products */,
+				CEDB7CAB2E4D564900A7583B /* LICENSE */,
 			);
 			sourceTree = "<group>";
 		};
@@ -99,6 +101,7 @@
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1620;
 				LastUpgradeCheck = 1620;
+				ORGANIZATIONNAME = Eliomane;
 				TargetAttributes = {
 					CE8494CC2E4B783300B03BD6 = {
 						CreatedOnToolsVersion = 16.2;
@@ -298,6 +301,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = GitLabMobile/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -313,7 +317,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.1;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.team.GitLabMobile.GitLabMobile;
+				PRODUCT_BUNDLE_IDENTIFIER = com.eliomane.GitLabMobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
@@ -337,6 +341,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = GitLabMobile/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -352,7 +357,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.1;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.team.GitLabMobile.GitLabMobile;
+				PRODUCT_BUNDLE_IDENTIFIER = com.eliomane.GitLabMobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";

--- a/GitLabMobile/GitLabMobile.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/GitLabMobile/GitLabMobile.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string>
+//  ___FILENAME___
+//  ___PROJECTNAME___
+//
+//  Copyright © ___YEAR___ ___ORGANIZATIONNAME___. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//</string>
+</dict>
+</plist>

--- a/GitLabMobile/GitLabMobile/ContentView.swift
+++ b/GitLabMobile/GitLabMobile/ContentView.swift
@@ -2,7 +2,8 @@
 //  ContentView.swift
 //  GitLabMobile
 //
-//  Created by User on 8/12/25.
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
 //
 
 import SwiftUI

--- a/GitLabMobile/GitLabMobile/Features/Account/Data/PersonalProjectsService.swift
+++ b/GitLabMobile/GitLabMobile/Features/Account/Data/PersonalProjectsService.swift
@@ -1,3 +1,11 @@
+//
+//  PersonalProjectsService.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public protocol PersonalProjectsServiceProtocol: Sendable {

--- a/GitLabMobile/GitLabMobile/Features/Explore/Components/ProjectRowItem.swift
+++ b/GitLabMobile/GitLabMobile/Features/Explore/Components/ProjectRowItem.swift
@@ -1,3 +1,11 @@
+//
+//  ProjectRowItem.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public struct ProjectRowItem: Identifiable, Sendable, Equatable {

--- a/GitLabMobile/GitLabMobile/Features/Explore/Data/ExploreProjectsService.swift
+++ b/GitLabMobile/GitLabMobile/Features/Explore/Data/ExploreProjectsService.swift
@@ -1,3 +1,11 @@
+//
+//  ExploreProjectsService.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public protocol ExploreProjectsServiceProtocol: Sendable {

--- a/GitLabMobile/GitLabMobile/Features/Explore/Presentation/ExploreCoordinator.swift
+++ b/GitLabMobile/GitLabMobile/Features/Explore/Presentation/ExploreCoordinator.swift
@@ -1,3 +1,11 @@
+//
+//  ExploreCoordinator.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import SwiftUI
 import Observation
 

--- a/GitLabMobile/GitLabMobile/Features/Explore/Presentation/Stores/ExploreProjectsStore.swift
+++ b/GitLabMobile/GitLabMobile/Features/Explore/Presentation/Stores/ExploreProjectsStore.swift
@@ -1,5 +1,12 @@
+//
+//  ExploreProjectsStore.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
-import Observation
 import Combine
 
 @MainActor

--- a/GitLabMobile/GitLabMobile/Features/Explore/Presentation/Views/ExploreProjectsView.swift
+++ b/GitLabMobile/GitLabMobile/Features/Explore/Presentation/Views/ExploreProjectsView.swift
@@ -1,3 +1,11 @@
+//
+//  ExploreProjectsView.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import SwiftUI
 
 public struct ExploreProjectsView: View {

--- a/GitLabMobile/GitLabMobile/Features/Explore/Presentation/Views/ExploreRootView.swift
+++ b/GitLabMobile/GitLabMobile/Features/Explore/Presentation/Views/ExploreRootView.swift
@@ -1,3 +1,11 @@
+//
+//  ExploreRootView.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import SwiftUI
 
 public struct ExploreRootView: View {

--- a/GitLabMobile/GitLabMobile/Features/Explore/Presentation/Views/ProjectRow.swift
+++ b/GitLabMobile/GitLabMobile/Features/Explore/Presentation/Views/ProjectRow.swift
@@ -1,3 +1,11 @@
+//
+//  ProjectRow.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import SwiftUI
 
 struct ProjectRow: View {

--- a/GitLabMobile/GitLabMobile/Features/Projects/Data/ProjectDetailsService.swift
+++ b/GitLabMobile/GitLabMobile/Features/Projects/Data/ProjectDetailsService.swift
@@ -1,3 +1,11 @@
+//
+//  ProjectDetailsService.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public protocol ProjectDetailsServiceProtocol: Sendable {

--- a/GitLabMobile/GitLabMobile/Features/Search/Data/ProjectSearchService.swift
+++ b/GitLabMobile/GitLabMobile/Features/Search/Data/ProjectSearchService.swift
@@ -1,3 +1,11 @@
+//
+//  ProjectSearchService.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public protocol ProjectSearchServiceProtocol: Sendable {

--- a/GitLabMobile/GitLabMobile/GitLabMobileApp.swift
+++ b/GitLabMobile/GitLabMobile/GitLabMobileApp.swift
@@ -2,7 +2,8 @@
 //  GitLabMobileApp.swift
 //  GitLabMobile
 //
-//  Created by User on 8/12/25.
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
 //
 
 import SwiftUI

--- a/GitLabMobile/GitLabMobile/Shared/AppEnvironment.swift
+++ b/GitLabMobile/GitLabMobile/Shared/AppEnvironment.swift
@@ -1,3 +1,11 @@
+//
+//  AppEnvironment.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Observation
 
 @MainActor

--- a/GitLabMobile/GitLabMobile/Shared/Domain/Entities/AuthToken.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Domain/Entities/AuthToken.swift
@@ -1,3 +1,11 @@
+//
+//  AuthToken.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public struct AuthToken: Codable, Sendable, Equatable {

--- a/GitLabMobile/GitLabMobile/Shared/Domain/Entities/ProjectSummary.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Domain/Entities/ProjectSummary.swift
@@ -1,3 +1,11 @@
+//
+//  ProjectSummary.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public struct ProjectSummary: Identifiable, Decodable, Equatable, Sendable, Hashable {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/APIClient+Config.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/APIClient+Config.swift
@@ -1,3 +1,11 @@
+//
+//  APIClient+Config.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public extension APIClient {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/APIClient.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/APIClient.swift
@@ -1,3 +1,11 @@
+//
+//  APIClient.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public struct APIClient: Sendable {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/AppPinning.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/AppPinning.swift
@@ -1,3 +1,11 @@
+//
+//  AppPinning.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 /// Loads SPKI pin hashes from Info.plist top-level key `GitLabSPKIPins` (Array<String>).

--- a/GitLabMobile/GitLabMobile/Shared/Networking/Auth/AuthorizationManager.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/Auth/AuthorizationManager.swift
@@ -1,3 +1,11 @@
+//
+//  AuthorizationManager.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public protocol AuthorizationManagerProtocol: Sendable {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/Auth/OAuthService.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/Auth/OAuthService.swift
@@ -1,3 +1,11 @@
+//
+//  OAuthService.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public struct OAuthService: Sendable {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/Auth/TokenStorage.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/Auth/TokenStorage.swift
@@ -1,3 +1,11 @@
+//
+//  TokenStorage.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 import Security
 

--- a/GitLabMobile/GitLabMobile/Shared/Networking/AuthProviding.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/AuthProviding.swift
@@ -1,3 +1,11 @@
+//
+//  AuthProviding.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public protocol AuthProviding: Sendable {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/DTOs/Auth/OAuthTokenDTO.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/DTOs/Auth/OAuthTokenDTO.swift
@@ -1,3 +1,11 @@
+//
+//  OAuthTokenDTO.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public struct OAuthTokenDTO: Codable, Sendable {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/DTOs/Projects/ProjectDTO.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/DTOs/Projects/ProjectDTO.swift
@@ -1,3 +1,11 @@
+//
+//  ProjectDTO.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public struct ProjectDTO: Decodable, Sendable, Equatable {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/ETagCache.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/ETagCache.swift
@@ -1,3 +1,11 @@
+//
+//  ETagCache.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 actor ETagCache {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/Endpoint.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/Endpoint.swift
@@ -1,3 +1,11 @@
+//
+//  Endpoint.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public struct Endpoint<Response: Decodable> {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/Endpoints/OAuthEndpoints.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/Endpoints/OAuthEndpoints.swift
@@ -1,3 +1,11 @@
+//
+//  OAuthEndpoints.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public enum OAuthEndpoints {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/Endpoints/ProjectsAPI.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/Endpoints/ProjectsAPI.swift
@@ -1,3 +1,11 @@
+//
+//  ProjectsAPI.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public enum ProjectsAPI {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/HTTPMethod.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/HTTPMethod.swift
@@ -1,3 +1,11 @@
+//
+//  HTTPMethod.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 public enum HTTPMethod: String {
     case get = "GET"
     case post = "POST"

--- a/GitLabMobile/GitLabMobile/Shared/Networking/JSONDecoder+GitLab.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/JSONDecoder+GitLab.swift
@@ -1,3 +1,11 @@
+//
+//  JSONDecoder+GitLab.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public extension JSONDecoder {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/NetworkError.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/NetworkError.swift
@@ -1,3 +1,11 @@
+//
+//  NetworkError.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public enum NetworkError: Error, LocalizedError {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/NetworkingConfig.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/NetworkingConfig.swift
@@ -1,3 +1,11 @@
+//
+//  NetworkingConfig.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public struct NetworkingConfig: Sendable {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/PageInfo.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/PageInfo.swift
@@ -1,3 +1,11 @@
+//
+//  PageInfo.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public struct PageInfo: Sendable, Equatable {

--- a/GitLabMobile/GitLabMobile/Shared/Networking/PinnedSessionDelegate.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/PinnedSessionDelegate.swift
@@ -1,3 +1,11 @@
+//
+//  PinnedSessionDelegate.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 import Security
 import CommonCrypto

--- a/GitLabMobile/GitLabMobile/Shared/Networking/RequestOptions.swift
+++ b/GitLabMobile/GitLabMobile/Shared/Networking/RequestOptions.swift
@@ -1,3 +1,11 @@
+//
+//  RequestOptions.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import Foundation
 
 public struct RequestOptions: Sendable, Equatable {

--- a/GitLabMobile/GitLabMobile/Shared/UI/AsyncImageView.swift
+++ b/GitLabMobile/GitLabMobile/Shared/UI/AsyncImageView.swift
@@ -1,3 +1,11 @@
+//
+//  AsyncImageView.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import SwiftUI
 import Kingfisher
 

--- a/GitLabMobile/GitLabMobile/Shared/UI/NavigationRow.swift
+++ b/GitLabMobile/GitLabMobile/Shared/UI/NavigationRow.swift
@@ -1,3 +1,11 @@
+//
+//  NavigationRow.swift
+//  GitLabMobile
+//
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
+//
+
 import SwiftUI
 
 public struct NavigationRow: View {

--- a/GitLabMobile/GitLabMobile/Shared/UI/Styles/LabelStyles.swift
+++ b/GitLabMobile/GitLabMobile/Shared/UI/Styles/LabelStyles.swift
@@ -2,7 +2,8 @@
 //  LabelStyles.swift
 //  GitLabMobile
 //
-//  Created by User on 8/13/25.
+//  Copyright © 2025 Eliomane. All rights reserved.
+//  Licensed under Apache License v2.0. See LICENSE file.
 //
 
 import SwiftUI


### PR DESCRIPTION
## Summary
Establish a consistent Apache 2.0 licensing policy across the project by adding a shared Xcode file header template and applying headers to existing Swift files. This is a non-functional change.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Configuration/Setup

## Changes Made
- Add IDETemplateMacros.plist under GitLabMobile.xcodeproj/xcshareddata
- Configure clean Apache v2.0 header format with organization and year placeholders
- Add LICENSE file reference in Xcode navigator only, not added to targets
- Prepend header to all .swift files that did not already contain the license line
- Set app category name to developer tools

## Testing
- [x] Code compiles without warnings
- [x] SwiftLint passes
- [ ] Manual testing completed
- [ ] Unit/UI tests added or updated
- [x] No regressions in existing functionality

## iOS Testing (if applicable)
- [ ] Tested on different screen sizes (iPhone SE, Pro, Pro Max)
- [ ] iPad compatibility verified (if supported)
- [ ] Works in both portrait and landscape
- [ ] Dark/Light mode compatible
- [ ] Accessibility considerations addressed (VoiceOver, Dynamic Type)
- [ ] Performance tested (smooth animations, no memory issues)

## Screenshots/Videos (if applicable)
<!-- Add screenshots or screen recordings for UI changes -->

## Additional Context
- New files will automatically receive the header via IDETemplateMacros; ensure teammates restart Xcode after pulling.
- The LICENSE file is referenced in the navigator for visibility but is not included in the app bundle.
- Organization name comes from the project setting (or the header can remain hard-coded in the template).
